### PR TITLE
Add --debug-info flag for Compass compile

### DIFF
--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -12,10 +12,17 @@ module.exports = function( grunt ) {
             outputstyle = this.data.outputstyle,
             linecomments = this.data.linecomments,
             forcecompile = this.data.forcecompile,
+            debugsass = this.data.debugsass,
             libRequire = this.data.require;
 
         if ( src !== undefined && dest !== undefined ) {
             command += ' --sass-dir="' + src + '" --css-dir="' + dest + '"';
+        }
+
+        if ( debugsass !== undefined ) {
+            if ( debugsass === true ) {
+                command += ' --debug-info';
+            }
         }
 
         if ( outputstyle !== undefined ) {


### PR DESCRIPTION
Hey there,

I regularly use Sass's debug mode in conjunction with FireSass to speed up work in Firefox; we're starting to use grunt and grunt-compass for our compile/watch, so this change makes it a ton easier to stay within grunt for dev.

More info on FireSass:

http://nex-3.com/posts/92-firesass-bridges-the-gap-between-sass-and-firebug
https://addons.mozilla.org/en-US/firefox/addon/firesass-for-firebug/
