### PR TITLE
Adding --images-dir and --relative-assets flags

### DIFF
--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -9,19 +9,31 @@ module.exports = function( grunt ) {
             command = "compass compile",
             src = this.data.src,
             dest = this.data.dest,
+            images = this.data.images,
             outputstyle = this.data.outputstyle,
             linecomments = this.data.linecomments,
             forcecompile = this.data.forcecompile,
             debugsass = this.data.debugsass,
+            relativeassets = this.data.relativeassets,
             libRequire = this.data.require;
 
         if ( src !== undefined && dest !== undefined ) {
             command += ' --sass-dir="' + src + '" --css-dir="' + dest + '"';
         }
 
+        if ( images !== undefined ) {
+            command += ' --images-dir="' + images + '"';
+        }
+
         if ( debugsass !== undefined ) {
             if ( debugsass === true ) {
                 command += ' --debug-info';
+            }
+        }
+
+        if ( relativeassets !== undefined ) {
+            if ( relativeassets === true ) {
+                command += ' --relative-assets';
             }
         }
 


### PR DESCRIPTION
Both of these flags are important for using the Compass helpers for spriting. Example usage:

```
compass: {
    app: {
        src: CSS + '/scss',
        dest: CSS + '/css',
        images: '/path/to/images',
        forcecompile: true,
        relativeassets: true
    }
}
```

See: http://compass-style.org/help/tutorials/configuration-reference for more info on those options.

Example of compass-generated compass.rb file that these settings approximate: http://stackoverflow.com/a/5499145/995529
