### PR TITLE
Added an option that runs compass with bundle exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ You need to have [node.js](http://nodejs.org/), [grunt.js](https://github.com/co
     relativeassets: true
     ```
 
-11. Run "grunt watch" and edit some SASS files :)
+11. You can run compass with bundle exec if you need to as well:
+
+    ```javascript
+    bundleExec: true
+    ```
+
+12. Run "grunt watch" and edit some SASS files :)
 
 # An Example Setup
 

--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -16,7 +16,8 @@ module.exports = function( grunt ) {
             forcecompile = this.data.forcecompile,
             debugsass = this.data.debugsass,
             relativeassets = this.data.relativeassets,
-            libRequire = this.data.require;
+            libRequire = this.data.require,
+            bundleExec = this.data.bundleExec;
 
         if ( this.data.src !== undefined ) {
             src = grunt.template.process(this.data.src);
@@ -24,6 +25,10 @@ module.exports = function( grunt ) {
 
         if ( this.data.dest !== undefined ) {
             dest = grunt.template.process(this.data.dest);
+        }
+
+        if ( bundleExec ) {
+            command = 'bundle exec ' + command;
         }
 
         if ( src !== undefined && dest !== undefined ) {


### PR DESCRIPTION
A project I'm working on uses a private compass extension which requires compass to be run with bundle exec, so I've added an option that let's me do that.
