### PR TITLE
Remove grunt as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "node": "*"
   },
   "dependencies": {
-    "grunt": ">=0.3.7"
   },
   "devDependencies": {
     "grunt": ">=0.3.7"


### PR DESCRIPTION
Hi! Could we remove grunt as a dependency? This way additional unneeded local copies of grunt isn't installed with each project that uses grunt-compass. Thanks!
