### PR TITLE
Adding -e flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ You need to have [node.js](http://nodejs.org/), [grunt.js](https://github.com/co
 
     If the path is not absolute, it is relative to the directory containing your gruntfile.
 
+13. If you have a Compass configuration file, you set the environment variable for the config.rb file:
+
+    ```javascript
+    environment: 'production'
+    ```
+
+    Then use it in your config.rb like so:
+
+    ```ruby
+    output_style = (environment == :production) ? :compressed : :expanded
+    ```
+
 13. Run "grunt watch" and edit some SASS files :)
 
 # An Example Setup

--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -19,6 +19,7 @@ module.exports = function( grunt ) {
             relativeassets = this.data.relativeassets,
             libRequire = this.data.require,
             bundleExec = this.data.bundleExec;
+            environment = this.data.environment;
 
         if ( this.data.src !== undefined ) {
             src = grunt.template.process(this.data.src);
@@ -74,6 +75,10 @@ module.exports = function( grunt ) {
 
         if ( forcecompile === true ) {
             command += ' --force';
+        }
+
+        if ( environment !== undefined ) {
+            command += ' -e ' + environment;
         }
 
         function puts( error, stdout, stderr ) {


### PR DESCRIPTION
The -e flag is used to set the environment variable in the config.rb file. Example:

```
$ compass compile -e production
```

Then you can inspect the value like so:

``` ruby
output_style = (environment == :production) ? :compressed : :expanded
```

See: http://compass-style.org/help/tutorials/configuration-reference/ for more info.
