### PR TITLE
Add globbing to `src` .

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ You need to have [node.js](http://nodejs.org/), [grunt.js](https://github.com/co
 	src: 'assets/scss/**/*.scss' // Match all scss files under `assets/scss` include files in subdirctory.
 	```
 
+	See [minimatch](https://github.com/isaacs/minimatch) for more globbing usage.
+
 	Note a SASS/SCSS file will be ignored if its filename begin with an underscore `_`. See [SASS-partials](http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#partials).
 
 5. You can set your custom output style like this:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ You need to have [node.js](http://nodejs.org/), [grunt.js](https://github.com/co
 
 	`src` is the folder with sass or scss files and `dest` is the folder where the css files will be placed.
 
+	Also, you can use `src` to specify certain files you want to compile:
+
+	A single file.
+
+	```javascript
+	src: 'assets/scss/base.scss'
+	```
+
+	Use globbing to match files, like:
+
+	```javascript
+	src: 'assets/scss/*.scss' // Match all scss files under `assets/scss` but not include files in subdirctory.
+	src: 'assets/scss/**/*.scss' // Match all scss files under `assets/scss` include files in subdirctory.
+	```
+
+	Note a SASS/SCSS file will be ignored if its filename begin with an underscore `_`. See [SASS-partials](http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#partials).
+
 5. You can set your custom output style like this:
 
     ```javascript
@@ -89,16 +106,14 @@ You need to have [node.js](http://nodejs.org/), [grunt.js](https://github.com/co
     output_style = (environment == :production) ? :compressed : :expanded
     ```
 
-13. `grunt compass-clean`
+13. New task: compass-clean
 
-    Sometimes it can be faster to execute `compass clean` and recompile for production instead of doing `--force` compile.
-    Now grunt-compass comes with a `grunt compass-clean` task that you can use when registering prod tasks in your gruntfile like:
+Sometimes it can be faster to execute `compass clean` and recompile for production instead of doing `--force` compile.
+Now grunt-compass comes with a `grunt compass-clean` task that you can use when registering prod tasks in your gruntfile like:
 
-    ```js
-    grunt.registerTask('prod', ['compass-clean', 'compass:prod']);
-    ```
-
-    Or just use it in watch task.
+```js
+grunt.registerTask('prod', ['compass-clean', 'compass:prod']);
+```
 
 14. Run "grunt watch" and edit some SASS files :)
 


### PR DESCRIPTION
Add globbing to `src`.

Use `--sass-dir`:

``` js
src: 'assets/scss/'
```

If `src` is not an exist directory, use `src` to do a `minimatch` job, and treat  all matched files as  arguments for command `compile`.

Say we have an directory below:

```
sass ----
    main.scss
    side.scss
    mod ---
        _mod_a.scss
        _mod_b.scss
        mod_c.scss 
```

The globbing job will like:

```
src: 'sass/main.scss' // only `sass/main.scss`
src: 'sass/*.scss' // main.scss, side.scss
src: 'sass/**/*.scss // main.scss, side.scss, mod_c.scss
```

Note, all underscore begined file will be ignored.
