### PR TITLE
Allow multiple requires to be included in config

### DIFF
--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -111,7 +111,14 @@ module.exports = function( grunt ) {
         }
 
         if ( libRequire !== undefined ) {
-            command += ' --require '+ libRequire;
+            if ( require('util').isArray(libRequire) ) {
+                libRequire.forEach(function(lib) {
+                    command += ' --require ' + lib;
+                });
+            }
+            else {
+                command += ' --require '+ libRequire;
+            }
         }
 
         if ( forcecompile === true ) {


### PR DESCRIPTION
I might be missing something, but right now it looks like you can only include one require in a compass command. Space delimited lists result in compass trying to compile individual files and a comma separated list results in errors being thrown.

This pull request adds a check for an array of requires and updates the command line command appropriately.
