### PR TITLE
Compatibility changes for Grunt v0.4

### DIFF
--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -1,7 +1,7 @@
-var Fs   = require( 'fs' );
-var Path = require( 'path' );
-
 module.exports = function( grunt ) {
+
+    // Internal lib.
+    var compass = require('./lib/compass').init(grunt);
 
     // Create a new multi task.
     grunt.registerMultiTask( 'compass', 'This triggers the `compass compile` command.', function() {
@@ -12,135 +12,13 @@ module.exports = function( grunt ) {
         var done = this.async();
 
         puts = function( error, stdout, stderr ) {
-            grunt.helper( 'consoleOutput', error, stdout, stderr, done );
+            compass.consoleOutput( error, stdout, stderr, done );
         };
 
-        command = grunt.helper( 'buildCommand', this.data );
+        command = compass.buildCommand( this.data, done );
 
         exec( command, puts );
 
         grunt.log.write( '`' + command + '` was initiated.' );
-    });
-
-    grunt.registerHelper( 'buildCommand', function( data ) {
-
-        var src, dest, specify, matchedFiles;
-        var command        = "compass compile";
-        var config         = data.config;
-        var images         = data.images;
-        var fonts          = data.fonts;
-        var outputstyle    = data.outputstyle;
-        var linecomments   = data.linecomments;
-        var forcecompile   = data.forcecompile;
-        var debugsass      = data.debugsass;
-        var relativeassets = data.relativeassets;
-        var libRequire     = data.require;
-        var bundleExec     = data.bundleExec;
-        var environment    = data.environment;
-        var importPath     = data.importPath;
-
-        if ( data.src !== undefined ) {
-            src = grunt.template.process( data.src );
-        }
-
-        if ( data.dest !== undefined ) {
-            dest = grunt.template.process( data.dest );
-        }
-
-        if( data.specify !== undefined ) {
-            specify = grunt.template.process( data.specify );
-        }
-
-        if ( bundleExec ) {
-            command = 'bundle exec ' + command;
-        }
-
-        if ( src !== undefined && dest !== undefined ) {
-            command += ' --sass-dir="' + src + '" --css-dir="' + dest + '"';
-
-            // Specify sass files to be compiled in directory `src`.
-            if ( specify !== undefined ) {
-
-                matchedFiles = grunt.file.expandFiles( specify );
-
-                if ( matchedFiles.length > 0 ) {
-                    // Add all files execept those which begin with an underscore to the `compile` command.
-                    matchedFiles.forEach( function( file ) {
-                        if ( Path.basename( file ).charAt( 0 ) != '_' ) {
-                            command += ' ' + file;
-                        }
-                    });
-                }
-                else {
-                    grunt.log.error( 'No file matched with: ' + specify );
-                    done( false );
-                }
-            }
-        }
-
-        if ( config !== undefined ) {
-            command += ' --config="' + config + '"';
-        }
-
-        if ( images !== undefined ) {
-            command += ' --images-dir="' + images + '"';
-        }
-
-        if ( fonts !== undefined ) {
-            command += ' --fonts-dir="' + fonts + '"';
-        }
-
-        if ( debugsass !== undefined ) {
-            if ( debugsass === true ) {
-                command += ' --debug-info';
-            }
-        }
-
-        if ( relativeassets !== undefined ) {
-            if ( relativeassets === true ) {
-                command += ' --relative-assets';
-            }
-        }
-
-        if ( outputstyle !== undefined ) {
-            command += ' --output-style ' + outputstyle;
-        }
-
-        if ( linecomments === false ) {
-            command += ' --no-line-comments';
-        }
-
-        if ( libRequire !== undefined ) {
-            command += ' --require '+ libRequire;
-        }
-
-        if ( forcecompile === true ) {
-            command += ' --force';
-        }
-
-        if ( environment !== undefined ) {
-            command += ' -e ' + environment;
-        }
-
-        if ( importPath !== undefined ) {
-            command += ' -I ' + importPath;
-        }
-
-        return command;
-    });
-
-    grunt.registerHelper( 'consoleOutput', function( error, stdout, stderr, done ) {
-
-        grunt.log.write( '\n\nCOMPASS output:\n' );
-        grunt.log.write( stdout );
-
-        // compass sends falsy error message to stderr... real sass/compass errors come in through the "error" variable.
-        if ( error !== null ) {
-            grunt.log.error( error );
-            done( false );
-        }
-        else {
-            done( true );
-        }
     });
 };

--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -1,0 +1,131 @@
+exports.init = function(grunt) {
+    'use strict';
+
+    var exports = {};
+
+    var path = require( 'path' );
+
+    // Build CSS with compass compile
+    exports.buildCommand = function( data, done ) {
+        var src, dest, specify, matchedFiles;
+        var command        = "compass compile";
+        var config         = data.config;
+        var images         = data.images;
+        var fonts          = data.fonts;
+        var outputstyle    = data.outputstyle;
+        var linecomments   = data.linecomments;
+        var forcecompile   = data.forcecompile;
+        var debugsass      = data.debugsass;
+        var relativeassets = data.relativeassets;
+        var libRequire     = data.require;
+        var bundleExec     = data.bundleExec;
+        var environment    = data.environment;
+        var importPath     = data.importPath;
+
+        if ( data.src !== undefined ) {
+            src = grunt.template.process( data.src );
+        }
+
+        if ( data.dest !== undefined ) {
+            dest = grunt.template.process( data.dest );
+        }
+
+        if ( data.specify !== undefined ) {
+            specify = grunt.template.process( data.specify );
+        }
+
+        if ( bundleExec ) {
+            command = 'bundle exec ' + command;
+        }
+
+        if ( src !== undefined && dest !== undefined ) {
+            command += ' --sass-dir="' + src + '" --css-dir="' + dest + '"';
+
+            // Specify sass files to be compiled in directory `src`.
+            if ( specify !== undefined ) {
+
+                matchedFiles = grunt.file.expandFiles( specify );
+
+                if ( matchedFiles.length > 0 ) {
+                    // Add all files execept those which begin with an underscore to the `compile` command.
+                    matchedFiles.forEach( function( file ) {
+                        if ( path.basename( file ).charAt( 0 ) !== '_' ) {
+                            command += ' ' + file;
+                        }
+                    });
+                }
+                else {
+                    grunt.log.error( 'No file matched with: ' + specify );
+                    done( false );
+                }
+            }
+        }
+
+        if ( config !== undefined ) {
+            command += ' --config="' + config + '"';
+        }
+
+        if ( images !== undefined ) {
+            command += ' --images-dir="' + images + '"';
+        }
+
+        if ( fonts !== undefined ) {
+            command += ' --fonts-dir="' + fonts + '"';
+        }
+
+        if ( debugsass !== undefined ) {
+            if ( debugsass === true ) {
+                command += ' --debug-info';
+            }
+        }
+
+        if ( relativeassets !== undefined ) {
+            if ( relativeassets === true ) {
+                command += ' --relative-assets';
+            }
+        }
+
+        if ( outputstyle !== undefined ) {
+            command += ' --output-style ' + outputstyle;
+        }
+
+        if ( linecomments === false ) {
+            command += ' --no-line-comments';
+        }
+
+        if ( libRequire !== undefined ) {
+            command += ' --require '+ libRequire;
+        }
+
+        if ( forcecompile === true ) {
+            command += ' --force';
+        }
+
+        if ( environment !== undefined ) {
+            command += ' -e ' + environment;
+        }
+
+        if ( importPath !== undefined ) {
+            command += ' -I ' + importPath;
+        }
+
+        return command;
+    };
+
+    // Output to the console
+    exports.consoleOutput = function( error, stdout, stderr, done ) {
+        grunt.log.write( '\n\nCOMPASS output:\n' );
+        grunt.log.write( stdout );
+
+        // compass sends falsy error message to stderr... real sass/compass errors come in through the "error" variable.
+        if ( error !== null ) {
+            grunt.log.error( error );
+            done( false );
+        }
+        else {
+            done( true );
+        }
+    };
+
+  return exports;
+};

--- a/test/test_compass.js
+++ b/test/test_compass.js
@@ -1,4 +1,5 @@
 var grunt = require( 'grunt' );
+var compass = require('../tasks/lib/compass').init(grunt);
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -34,7 +35,7 @@ exports[ 'compass' ] = {
         dest: 'css'
     };
 
-    test.equal( grunt.helper( 'buildCommand', data ),
+    test.equal( compass.buildCommand( data ),
         'compass compile --sass-dir="sass" --css-dir="css"',
         'should return the correct command.' );
     test.done();


### PR DESCRIPTION
Hey Kahlil! Helpers were removed in Grunt v0.4. As promised, this makes grunt-compass compatible with Grunt v0.3 and v0.4 using the [grunt-contrib-\* style](https://github.com/gruntjs/grunt-contrib-jshint/tree/master/tasks) where reusable bits are placed in `tasks/lib/` and wrapped in an init grunt function.

Thanks!
