### PR TITLE
Enable travic-ci for automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 0.8
+  - 0.6

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://secure.travis-ci.org/aslansky/grunt-compass.png)](http://travis-ci.org/aslansky/grunt-compass)
+
 # grunt-compass
 
 This is a custom grunt.js multitask aka [gruntplugin](http://jsfiddle.net/cowboy/qzRjD/show/) that executes `compass compile` on the command line for you and prints the COMPASS output to `grunt.log.write()`.

--- a/package.json
+++ b/package.json
@@ -26,9 +26,19 @@
   "engines": {
     "node": "*"
   },
+  "scripts": {
+    "test": "nodeunit test/*"
+  },
   "dependencies": {},
   "devDependencies": {
-    "grunt": ">=0.3.7"
+    "grunt": ">=0.3.7",
+    "nodeunit": "~0.7.4"
   },
-  "keywords": ["grunt.js", "sass", "compass", "grunt", "gruntplugin"]
+  "keywords": [
+    "grunt.js",
+    "sass",
+    "compass",
+    "grunt",
+    "gruntplugin"
+  ]
 }


### PR DESCRIPTION
Because happily there are now tests for this plugin, so it would be great to use travis-ci to run them automatically. This pull request adds .travis.yml configurations file and nodeunit as a development dependency.

For more info see: http://about.travis-ci.org/docs/user/languages/javascript-with-nodejs/
