### PR TITLE
Images path updated to use grunt.template.process

### DIFF
--- a/tasks/lib/compass.js
+++ b/tasks/lib/compass.js
@@ -31,6 +31,10 @@ exports.init = function( grunt ) {
             dest = grunt.template.process( data.dest );
         }
 
+				if ( data.images !== undefined ) {
+					images = grunt.template.process( data.images );
+				}
+
         if ( data.specify !== undefined ) {
             specify = grunt.template.process( data.specify );
         }


### PR DESCRIPTION
The image path is now processed through grunt.template. Therefore you
can have the images path as dynamic.
